### PR TITLE
Argument to 'idris --client' is now a single arg.

### DIFF
--- a/Idris.py
+++ b/Idris.py
@@ -17,7 +17,7 @@ class RunIdrisCommandCommand(sublime_plugin.TextCommand):
 
         def idris_cmd(cmd, l, n):
             args = [str(l), n] if editing else []
-            return (["idris", "--client", cmd] + args)
+            return (["idris", "--client", " ".join([cmd] + args)])
 
         def run_cmd(cmd):
             env = os.environ


### PR DESCRIPTION
Since switching to optparse-applicative, idris --client now takes a
single argument, rather than passing all remaining arguments to the
idris repl.  You can see in the vim mode that arg is now quoted, to
prevent it from being treated as seperate arguments by the shell:
https://github.com/idris-hackers/idris-vim/blob/master/ftplugin/idris.vim#L74

This patch seems to fix that behaviour; however, reloading of the
current buffer from disk is still needed to see the changes done by
idris.
